### PR TITLE
버그 수정 및 기능 개선

### DIFF
--- a/smi2srt
+++ b/smi2srt
@@ -26,6 +26,7 @@ if(SUFFIX in langcodeConvRules):
 
 def parse(smi): # smi parsing algorithm written in PYSAMI by g6123 (https://github.com/g6123/PySAMI)
     search = lambda string, pattern: re.search(pattern, string, flags=re.I)
+    tags = re.compile('<[^>]+>')
 
     def split_content(string, tag):
         threshold = '<'+tag
@@ -35,14 +36,21 @@ def parse(smi): # smi parsing algorithm written in PYSAMI by g6123 (https://gith
             re.split(threshold, string, flags=re.I)
         ))[1:]
 
+    def remove_tag(matchobj):
+        matchtag = matchobj.group().lower()
+        keep_tags = ['font', 'b', 'i', 'u']
+        for keep_tag in keep_tags:
+            if keep_tag in matchtag:
+                return matchtag
+        return ''
+
     def parse_p(item):
         lang = search(item, '<p(.+)class=([a-z]+)').group(2)
         content = item[search(item, '<p[^>]+>').end():]
         content = content.replace('\r', '')
         content = content.replace('\n', '')
         content = re.sub('<br ?/?>', '\n', content, flags=re.I)
-        content = re.sub('<[^>]+>','', content)
-        content = content.strip()
+        content = re.sub('<[^>]+>', remove_tag, content)
         return [lang, content]
 
     data = []
@@ -56,6 +64,7 @@ def parse(smi): # smi parsing algorithm written in PYSAMI by g6123 (https://gith
                 data.append([timecode, content])
     except:
         print('Conversion ERROR: maybe this file is not supported.')
+    
     return data
 
 def convert(data, lang): # written by ncianeo
@@ -86,7 +95,7 @@ def convert(data, lang): # written by ncianeo
             if data[i][1][lang]!='&nbsp;':
                 srt+=str(sub_nb)+'\n'
                 sub_nb+=1
-                if data[i+1][0]>data[i][0]:
+                if int(data[i+1][0])>int(data[i][0]):
                     srt+='%02d:%02d:%02d,%03d' %ms_to_ts(data[i][0])+' --> '+'%02d:%02d:%02d,%03d\n' %ms_to_ts(data[i+1][0])
                 else:
                     srt+='%02d:%02d:%02d,%03d' %ms_to_ts(data[i][0])+' --> '+'%02d:%02d:%02d,%03d\n' %ms_to_ts(int(data[i][0])+1000)


### PR DESCRIPTION
잘 사용하고 있습니다. ^^)/
사용중에 몇가지 불편한점이 발생해서 수정하였습니다.

1. time 비교 버그 수정

`convert` 함수 에서 시간을 비교하여, 다음 시간이 현재 시간보다 작을 경우 예외처리 하는 부분이 있습니다.
`data[i+1][0] > data[i][0]` 이 부분인데, 문제는 time 데이터가 int형이 아닌 string 형으로 들어오고 있어 자리수가 변할 때 재대로 비교가 이루어지지 않습니다.
결과적으로 자막이 사라지는 현상이 나타나게 됩니다.

=> int 형으로 타입 캐스팅 하여 버그 수정하였습니다.

2. font, b, i, u 태그 남김

플레이어마다 다르지만, 몇몇 플레이어에서 SRT 태그에 html 태그를 허용하고 있습니다.
(지원되는 플레이어 예, ffmpeg, plex web app, kodi, ...)
기존 변환식의 경우 html 태그를 싸그리 날리고 있습니다.

=> font, b, i, u 태그에 대해 HTML 코드 남기도록 변경하였습니다.